### PR TITLE
Removes menu_cache_clear_all from D8 installation

### DIFF
--- a/drush/install.provision.inc
+++ b/drush/install.provision.inc
@@ -45,9 +45,6 @@ function drush_provision_civicrm_post_provision_install($url = null) {
     db_query("UPDATE {system} SET weight = 100 WHERE name = 'civicrm'");
   }
 
-  // Update the menu router and cache information.
-  menu_cache_clear_all();
-
   // Create a CiviCRM dashboard link in the navigation menu.
   if (drush_drupal_major_version() <= 7) {
     // Create a CiviCRM dashboard link in the navigation menu.
@@ -60,12 +57,13 @@ function drush_provision_civicrm_post_provision_install($url = null) {
       'options' => array('alter' => TRUE),
     );
     menu_link_save($options_dashboard);
+
+    // Update the menu router and cache information.
+    menu_cache_clear_all();
+
+    drush_log(dt("CiviCRM: dashboard link in the navigation menu added in drush_provision_civicrm_post_provision_install."), 'ok');
   }
 
-  // Update the menu router and cache information.
-  menu_cache_clear_all();
-
-  drush_log(dt("CiviCRM: dashboard link in the navigation menu added in drush_provision_civicrm_post_provision_install."), 'ok');
   drush_log(dt("CiviCRM: Installation complete!"), 'ok');
 }
 


### PR DESCRIPTION
It seems that there was a command that slipped out of the conditional actions when building the menu structure on D7 (and when ignoring it on D8/D9).

This commit fixes that issue.

The issue appears during installation of a website on D8 + CiviCRM 5.x