### PR TITLE
Fixes query error during verification on D9

### DIFF
--- a/drush/provision_civicrm.inc
+++ b/drush/provision_civicrm.inc
@@ -738,7 +738,6 @@ function _provision_civicrm_database_version() {
 
     case 7:
     case 8:
-    case 9:
       $dbVer = db_query('select version from civicrm_domain where id = :id', array(':id' => CIVICRM_DOMAIN_ID))->fetchField();
       break;
     case 9:


### PR DESCRIPTION
During verification of a D9 website, we got the following error:

`Error: Call to undefined function db_query() in _provision_civicrm_database_version() (line 742 of /data/disk/xxx/aegir/distro/002/profiles/hostmaster/modules/aegir/hosting_civicrm/drush/provision_civicrm.inc)`

This minor adjustment resolves that